### PR TITLE
Fix env var support for security-sensitive flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Fixed support for app token and user key via env vars
+
 ## [0.0.1] - 2019-01-16
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -34,21 +34,24 @@ func configureRootCommand() *cobra.Command {
 		RunE:  run,
 	}
 
+	/*
+	   Security Sensitive flags
+	     - default to using envvar value
+	     - do not mark as required
+	     - manually test for empty value
+	*/
+
 	cmd.Flags().StringVarP(&appToken,
 		"app.token",
 		"a",
 		os.Getenv("PUSHOVER_APP_TOKEN"),
 		"Pushover v1 API app token, use default from PUSHOVER_APP_TOKEN env var")
 
-	_ = cmd.MarkFlagRequired("app.token")
-
 	cmd.Flags().StringVarP(&userKey,
 		"user.key",
 		"u",
 		os.Getenv("PUSHOVER_USER_KEY"),
 		"Pushover v1 API user key, use default from PUSHOVER_USER_KEY env var")
-
-	_ = cmd.MarkFlagRequired("user.key")
 
 	return cmd
 }
@@ -61,6 +64,16 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if stdin == nil {
 		stdin = os.Stdin
+	}
+
+	if appToken == "" {
+		_ = cmd.Help()
+		return fmt.Errorf("app token is empty")
+	}
+
+	if userKey == "" {
+		_ = cmd.Help()
+		return fmt.Errorf("user key is empty")
 	}
 
 	eventJSON, err := ioutil.ReadAll(stdin)


### PR DESCRIPTION
The app token and user key flags are meant to support providing values via env vars. This change makes those flags optional via cobra, and manually ensures both flags have values provided.